### PR TITLE
Fix for moves resulting in incorrect bounds

### DIFF
--- a/MoveIt.sketchplugin/Contents/Sketch/manifest.json
+++ b/MoveIt.sketchplugin/Contents/Sketch/manifest.json
@@ -3,7 +3,7 @@
   "author" : "Dawid Woźniak",
   "description" : "Let's you move selected layers verticaly and horizontaly.",
   "authorEmail" : "dawid@plaind.pl",
-  "version" : "1.0",
+  "version" : "1.0.1",
   "commands" : [
     {
       "script" : "script.cocoascript",

--- a/MoveIt.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/MoveIt.sketchplugin/Contents/Sketch/script.cocoascript
@@ -10,7 +10,9 @@ var onRun = function(context) {
     while (item = loop.nextObject()) {
       item.frame().setX(parseFloat(item.frame().x()) + parseFloat(options['new_x']));
       item.frame().setY(parseFloat(item.frame().y()) + parseFloat(options['new_y']));
-      item.adjustToFit();
+      if (item.layers && object.layers.length) {
+      	item.adjustToFit();
+      }
     }
 
   } else {

--- a/MoveIt.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/MoveIt.sketchplugin/Contents/Sketch/script.cocoascript
@@ -10,6 +10,7 @@ var onRun = function(context) {
     while (item = loop.nextObject()) {
       item.frame().setX(parseFloat(item.frame().x()) + parseFloat(options['new_x']));
       item.frame().setY(parseFloat(item.frame().y()) + parseFloat(options['new_y']));
+      item.adjustToFit();
     }
 
   } else {


### PR DESCRIPTION
In Sketch v56, performing a MoveIt operation on a group will leave the group's bounds out of date, making object selection difficult.

This update attempts to solve the issue by applying `adjustToFit()` when a moved item has any child layers.